### PR TITLE
TTGO T-Beam with reduced upload_speed

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -125,6 +125,7 @@ build_flags =
     ${extra.build_flags_psram} ; 8MB PSRAM
 lib_deps =
     ${esp32.lib_deps}
+upload_speed = 460800
 
 ; ************
 ; * ESP32-C6 *


### PR DESCRIPTION
TTGO T-Beam v1.x only supports an upload_speed of 460800 baud